### PR TITLE
Add 'Close Hue' game to dailies

### DIFF
--- a/dailies.md
+++ b/dailies.md
@@ -123,6 +123,7 @@ Add an [issue on GitHub](https://github.com/AdoryVo/lists/issues) or email busin
 - [Chronophoto](https://www.chronophoto.app) (♾️) - Guess the year pictures are taken in
 - 🆕 [ClueTube](https://thecluetube.com) (⭐) - Guess the YouTube video based on its comments
 - 🆕 [The Daily Hue](https://thedailyhue.com) (⭐) - Guess the color from the famous artwork by adjusting and matching HSL sliders
+- 🆕 [Close Hue](https://closehue.com) (⭐) - Given a color name, pick which color swatch matches it. Scored on how close your guess is. Daily challenges, unlimited mode, and multiplayer.
 
 ---
 ## Curations


### PR DESCRIPTION
Adding Close Hue (https://closehue.com) to the Miscellaneous section.

Close Hue is a daily color-guessing game where you are given a color name and have to identify what the color looks like. You pick from 5 color swatches and are scored on how close your guess is. Features daily challenges, unlimited mode, and multiplayer. It fits right alongside The Daily Hue in the Miscellaneous section!