### PR TITLE
Add Statedoku to 🌍 World

### DIFF
--- a/dailies.md
+++ b/dailies.md
@@ -117,6 +117,7 @@ Add an [issue on GitHub](https://github.com/AdoryVo/lists/issues) or email busin
 - [Chartle](https://chartle.cc) (⭐) - Guess the country based on the mystery country's chart trajectory compared to other countries.
 - [Globle](https://globle-game.com) - Guess the country on a globe with hints based on proximity (hot or cold)
 - [Juxtastat](https://urbanstats.org/quiz.html) - Choose between two locations for meeting a specific urban statistic
+- 🆕 [Statedoku](https://statedoku.com) (🔀) - Fill a 3×3 grid with US states matching both a row clue and a column clue (e.g. "borders Canada" × "no income tax")
 - [TimeGuessr](https://timeguessr.com) (♾️) - Guess the time and location pictures are taken in
 - [Tradle](https://oec.world/en/tradle) - Guess the country based on their trade exports
 - [Travle](https://imois.in/games/travle) - Guess countries to make a connected land path between two given countries


### PR DESCRIPTION
Adding **Statedoku** to the World section — fits alongside Globle, Worldle, and Tradle.

**Statedoku** — Daily 3×3 grid where each cell must be a US state matching both its row clue and column clue (e.g. "borders Canada" × "no income tax"). 100+ rotating clues, free, no signup, multilingual (EN/FR/ES), replayable archive.

→ https://statedoku.com

Inserted alphabetically and tagged 🆕 + 🔀 (replayable). Thanks for the great list!